### PR TITLE
Fix #14 - no error if id file not found

### DIFF
--- a/cmd/octopus/copy/copy.go
+++ b/cmd/octopus/copy/copy.go
@@ -30,7 +30,10 @@ var CopyCmd = &cobra.Command{
 		remoteDir := args[n-1]
 		logger.Info.Println("copying", len(localSources), "local sources", localSources, "to remote dir", remoteDir)
 
-		o := config.TrainOctopus()
+		o, err := config.TrainOctopus()
+		if err != nil {
+			return err
+		}
 
 		opts := tentacle.NewCopyFileOptions(viper.GetBool("recursive"))
 		numErrs, err := o.Do(tentacle.FileCopier(localSources, remoteDir, opts))

--- a/cmd/octopus/run/run.go
+++ b/cmd/octopus/run/run.go
@@ -29,7 +29,10 @@ var RunCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger.Info.Println("Running command: ", args[0])
 
-		o := config.TrainOctopus()
+		o, err := config.TrainOctopus()
+		if err != nil {
+			return err
+		}
 
 		numErrs, err := o.Do(tentacle.CommandRunner(args[0]))
 		if err != nil {

--- a/internal/octopus/groupsfile.go
+++ b/internal/octopus/groupsfile.go
@@ -17,7 +17,7 @@ var getAddrsFromGroupsFile = func(hostGroups []string, groupsFile string) ([]str
 
 	f, err := os.Open(groupsFile)
 	if err != nil {
-		return []string{}, fmt.Errorf("could not load groups file %s: %+v", groupsFile, err)
+		return []string{}, fmt.Errorf("could not load groups file: %+v", err)
 	}
 
 	fileGroups, err := getAllGroupsInFile(f)

--- a/internal/ssh/connection.go
+++ b/internal/ssh/connection.go
@@ -34,7 +34,7 @@ func (c *Connector) AddIdentityFile(filePath string) error {
 
 	key, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("unable to read identity file %s. %+v", filePath, err)
+		return err
 	}
 
 	signer, err := ssh.ParsePrivateKey(key)

--- a/test/tests/01_config.sh
+++ b/test/tests/01_config.sh
@@ -20,6 +20,15 @@ assert_success "with --groups-file arg" \
 assert_success "with -f arg" octopus -g all -f "$HOME/work/groups-file" run hostname
 mv "$HOME/work/groups-file" "$GROUPFILE"
 
+# test unreadable config files
+mkdir -p "$HOME/work"
+touch "$HOME/work/unreadable-file"
+chmod 333 "$HOME/work/unreadable-file" # write-only
+assert_failure "with unreadable identity file" \
+  octopus -g all -i "$HOME/work/unreadable-file" run hostname
+assert_failure "with unreadable groups file" \
+  octopus -g all -f "$HOME/work/unreadable-file" run hostname
+
 # Start a second ssh daemon on hosts listening on port 3022 to test connecting to different port
 assert_success "with ssh daemon running on port 3022" \
   octopus -g all run '/usr/sbin/sshd -p 3022'


### PR DESCRIPTION
Fixes #14

If there is an error reading the identity file, return failure.

Also make sure that the same applies for reading the groups file.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>