### PR TITLE
Add copy buffer-size and requests-per-file options

### DIFF
--- a/cmd/octopus/copy/copy.go
+++ b/cmd/octopus/copy/copy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/BlaineEXE/octopus/internal/ssh"
+
 	"github.com/BlaineEXE/octopus/internal/tentacle"
 
 	"github.com/spf13/cobra"
@@ -35,6 +37,11 @@ var CopyCmd = &cobra.Command{
 			return err
 		}
 
+		ssh.UserSFTPOptions.BufferSizeKib = uint16(viper.GetInt("buffer-size"))
+		ssh.UserSFTPOptions.RequestsPerFile = uint16(viper.GetInt("requests-per-file"))
+		logger.Info.Println("SFTP buffer size (kib):", ssh.UserSFTPOptions.BufferSizeKib)
+		logger.Info.Println("SFTP requests per file:", ssh.UserSFTPOptions.RequestsPerFile)
+
 		opts := tentacle.NewCopyFileOptions(viper.GetBool("recursive"))
 		numErrs, err := o.Do(tentacle.FileCopier(localSources, remoteDir, opts))
 		if err != nil {
@@ -47,6 +54,10 @@ var CopyCmd = &cobra.Command{
 
 func init() {
 	CopyCmd.Flags().BoolP("recursive", "r", false, "recurse into subdirectories and copy all files")
+	CopyCmd.Flags().Uint16P("buffer-size", "B", 32,
+		"in kibibits (kib), maximum buffer (chunk) size for copying files (default is "+
+			"guaranteed-to-work max for all SFTP clients, OpenSSH max is 256 kib)")
+	CopyCmd.Flags().Uint16P("requests-per-file", "R", 64, "max number of concurrent requests per file")
 
 	viper.BindPFlags(CopyCmd.Flags())
 }

--- a/internal/ssh/connection_test.go
+++ b/internal/ssh/connection_test.go
@@ -115,6 +115,7 @@ func TestConnector_Connect(t *testing.T) {
 		return &Actor{
 			host:            host,
 			sshClient:       stubClient,
+			sftpOptions:     SFTPOptions{BufferSizeKib: 32, RequestsPerFile: 64},
 			_sftpCreateOnce: sync.Once{},             // must init the sync.Once for SFTP
 			_sftpClient:     nil,                     // do not create an sftp client on SSH connect
 			_sftpClientErr:  nil,                     // do not report SFTP client err on SSH connect

--- a/internal/ssh/copy.go
+++ b/internal/ssh/copy.go
@@ -21,7 +21,7 @@ func (a *Actor) CreateRemoteDir(dirPath string) error {
 	errMsg := "failed to create remote dir " + dirPath + ". %+v"
 	c, err := a.sftpClient()
 	if err != nil {
-		return fmt.Errorf(errMsg, err)
+		return err
 	}
 	if fi, err := statRemote(c, dirPath); err == nil {
 		if !fi.IsDir() {
@@ -48,20 +48,19 @@ var closeRemoteFile = func(f *sftp.File) error {
 
 // CopyFileToRemote copies the file to the Actor's remote host at the remote file path.
 func (a *Actor) CopyFileToRemote(localSource *os.File, remoteFilePath string) error {
-	errMsg := "failed to copy file to remote at " + remoteFilePath + ". %+v"
 	c, err := a.sftpClient()
 	if err != nil {
-		return fmt.Errorf(errMsg, err)
+		return err
 	}
 
 	d, err := createRemote(c, remoteFilePath)
 	if err != nil {
-		return fmt.Errorf(errMsg, err)
+		return fmt.Errorf("failed to create remote file handler at path %s. %+v", remoteFilePath, err)
 	}
 	defer closeRemoteFile(d)
 
 	if _, err := writeToRemote(d, localSource); err != nil {
-		return fmt.Errorf(errMsg, err)
+		return fmt.Errorf("failed to write to remote file %s. %+v", remoteFilePath, err)
 	}
 
 	return nil

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -28,11 +28,11 @@ run_test 01_config.sh
 run_test 02_run.sh
 run_test 03_copy.sh
 
-# # stop the first test host to simulate a node being unreachable
-# # host can't be restarted except by creating a new one, so make sure to do this very last
-# host=$HOST_BASENAME-1
-# docker stop "$host" 1> /dev/null
-# run_test 04_node-offline.sh
+# stop the first test host to simulate a node being unreachable
+# host can't be restarted except by creating a new one, so make sure to do this very last
+host=$HOST_BASENAME-1
+docker stop "$host" 1> /dev/null
+run_test 04_node-offline.sh
 
 echo "Test suites run: $num_suites"
 echo "Test failures: $num_failures"

--- a/test/tests/01_config.sh
+++ b/test/tests/01_config.sh
@@ -40,6 +40,7 @@ assert_success "  ... with -p arg" octopus -g all -p 3022 run hostname
 assert_success "  and finally killing ssh daemon on port 3022" \
   octopus -g all run 'pkill --full "/usr/sbin/sshd -p 3022"'
 
+# alternate user
 assert_success "with default user (root)" octopus -g all run 'id --user --name'
 assert_output_count "root" $NUM_HOSTS
 assert_failure "with invalid user" octopus -g all -u 'invalid' run 'ls'


### PR DESCRIPTION
Add option to change the buffer size of file chunks being copied and the
number of simultaneous file chunks which can be copied.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>