### PR TITLE
Copy with file permissions intact

### DIFF
--- a/cmd/octopus/config/cli.go
+++ b/cmd/octopus/config/cli.go
@@ -25,10 +25,11 @@ var OctopusCmd = &cobra.Command{
 
   Octopus is a simple pdsh-inspired commandline tool for running the same
   command on multiple remote hosts in parallel. Hosts are grouped together
-  into "host groups" in a file which inspired by pdsh's "genders" file. The
+  into "host groups" in a file which inspired by a "genders" file. The
   host groups file for Octopus is actually a Bash file with groups defined by
   variable definitions. This is so that the same file may be used easily by
-  both Octopus and by user-made scripts.
+	both Octopus and by user-made scripts and has the secondary benefit of
+	supporting defining hosts by IP address as well as hostname.
 
   Under the hood, Octopus uses ssh connections, and some ssh arguments are
   reflected in Octopus's arguments. These arguments are marked in the help

--- a/internal/octopus/octopus_test.go
+++ b/internal/octopus/octopus_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/BlaineEXE/octopus/internal/remote"
 	remotetest "github.com/BlaineEXE/octopus/internal/remote/test"
-	"github.com/BlaineEXE/octopus/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,6 +101,8 @@ func TestOctopus_Do(t *testing.T) {
 			}
 			tt.remoteConnector.ReturnActor = &remotetest.MockRemoteActor{}
 			tt.remoteConnector.ReturnActor.HostnameError = tt.failHostname
+			tt.remoteConnector.HostConnects = []string{}
+			tt.remoteConnector.HostConnectFails = []string{}
 			failActions = tt.failActions
 			failGetAddrsFromGroupsFile = tt.failGetAddrsFromGroupsFile
 
@@ -115,10 +116,8 @@ func TestOctopus_Do(t *testing.T) {
 				assert.Equal(t, tt.wants.numHostErrors, gotNumHostErrors)
 			}
 
-			connects := remotetest.Clear(&tt.remoteConnector.HostConnects)
-			connectFails := remotetest.Clear(&tt.remoteConnector.HostConnectFails)
-			testutil.CompareStringLists(t, tt.wants.connects, connects, "connects")
-			testutil.CompareStringLists(t, tt.wants.connectFails, connectFails, "connect fails")
+			assert.ElementsMatch(t, tt.wants.connects, tt.remoteConnector.HostConnects, "connects")
+			assert.ElementsMatch(t, tt.wants.connectFails, tt.remoteConnector.HostConnectFails, "connect fails")
 			// Connector should return all expected actors except those that fail connection
 			successfulConns := len(tt.wants.connects) - len(tt.wants.connectFails)
 			assert.Equal(t, successfulConns, len(actorsCalled))

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -34,11 +34,11 @@ type Actor interface {
 
 	// CreateRemotedir should create a directory along with any nonexistent parents on the remote
 	// host specified in the Connector.Connect method. Should return nil if the paths already exist.
-	CreateRemoteDir(dirPath string) error
+	CreateRemoteDir(dirPath string, perms os.FileMode) error
 
 	// CopyFileToRemote should copy the file to the remote host specified in the Connector.Connect
 	// method at the remote path, and the remote path includes the remote file name.
-	CopyFileToRemote(localSource *os.File, remoteFilePath string) error
+	CopyFileToRemote(localSource *os.File, remoteFilePath string, perms os.FileMode) error
 
 	// Close should close all necessary connections the Actor has made.
 	Close() error

--- a/internal/remote/test/actor.go
+++ b/internal/remote/test/actor.go
@@ -20,8 +20,10 @@ type MockRemoteActor struct {
 	// Results
 	Commands       []string // all commands actor has attempted to run
 	DirCreates     []string // all dirs actor has attempted to create (incl. failed ones)
+	DirCreateModes []os.FileMode
 	DirCreateFails []string // dirs actor has failed to create
 	FileCopies     []string // all files actor has attempted to copy (incl. failed ones)
+	FileCopyModes  []os.FileMode
 	FileCopyFails  []string // files actor has failed to copy
 	CloseCalled    int      // Close has been called this many times
 }
@@ -70,10 +72,11 @@ func ExpectedCommandOutput(command string, err bool) (stdout, stderr string) {
 
 // CreateRemoteDir is a mock function that appends each remote dir path to DirCreates.
 // It will return an error after it has been called CreateDirErrorAfter number of times.
-func (m *MockRemoteActor) CreateRemoteDir(dirPath string) error {
+func (m *MockRemoteActor) CreateRemoteDir(dirPath string, mode os.FileMode) error {
 	actorMutex.Lock()
 	defer actorMutex.Unlock()
 	app(&m.DirCreates, dirPath)
+	m.DirCreateModes = append(m.DirCreateModes, mode)
 
 	if m.CreateDirErrorOn != "" && strings.Contains(dirPath, m.CreateDirErrorOn) {
 		app(&m.DirCreateFails, dirPath)
@@ -84,10 +87,11 @@ func (m *MockRemoteActor) CreateRemoteDir(dirPath string) error {
 
 // CopyFileToRemote is a mock function that appends each remote file path to FileCopies.
 // It will return an error after it has been called CopyFileErrorAfter number of times.
-func (m *MockRemoteActor) CopyFileToRemote(localSource *os.File, remoteFilePath string) error {
+func (m *MockRemoteActor) CopyFileToRemote(localSource *os.File, remoteFilePath string, mode os.FileMode) error {
 	actorMutex.Lock()
 	defer actorMutex.Unlock()
 	app(&m.FileCopies, remoteFilePath)
+	m.FileCopyModes = append(m.FileCopyModes, mode)
 
 	if m.CopyFileErrorOn != "" && strings.Contains(remoteFilePath, m.CopyFileErrorOn) {
 		app(&m.FileCopyFails, remoteFilePath)

--- a/internal/ssh/actor.go
+++ b/internal/ssh/actor.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// SFTPOptions is defines options for SSH's SFTP subsystem.
 type SFTPOptions struct {
 	BufferSizeKib   uint16
 	RequestsPerFile uint16

--- a/internal/tentacle/copy_test.go
+++ b/internal/tentacle/copy_test.go
@@ -16,7 +16,6 @@ import (
 func TestFileCopier(t *testing.T) {
 	tmpRoot, cleanup := testutil.TempDir("")
 	defer cleanup()
-	defer os.RemoveAll(tmpRoot)
 	fileA := path.Join(tmpRoot, "fileA")
 	fileB := path.Join(tmpRoot, "fileB")
 	dirA := path.Join(tmpRoot, "dirA")
@@ -28,12 +27,14 @@ func TestFileCopier(t *testing.T) {
 	dirWO := path.Join(tmpRoot, "dirWO")   // write only dir
 	fileWOA := path.Join(dirWO, "fileWOA") // rw file in write only dir
 	allFiles := []string{fileA, fileB, fileAA, fileAB, fileBA, fileWO, fileWOA}
-	for _, f := range allFiles {
-		os.MkdirAll(path.Dir(f), 0777)
-		testutil.WriteFile(f, path.Base(f), 0777) // file's text is its filename
+	allModes := []os.FileMode{0755, 0750, 0700, 0760, 0770, 0222, 0777}
+	for i, f := range allFiles {
+		os.MkdirAll(path.Dir(f), 0744)                   // must be 07-- or test will fail
+		testutil.WriteFile(f, path.Base(f), allModes[i]) // file's text is its filename
 	}
-	os.Chmod(fileWO, 0222)
+	os.Chmod(dirB, 0777)
 	os.Chmod(dirWO, 0222)
+	defer os.Chmod(dirWO, 0777) // need to be able to delete this later
 
 	recursive := NewCopyFileOptions(true)
 	notRecursive := NewCopyFileOptions(false)
@@ -45,8 +46,10 @@ func TestFileCopier(t *testing.T) {
 	}
 	type wants struct {
 		dirs      []string
+		dirModes  []os.FileMode
 		dirFails  []string
 		files     []string
+		fileModes []os.FileMode
 		fileFails []string
 		err       bool
 	}
@@ -60,21 +63,26 @@ func TestFileCopier(t *testing.T) {
 			args{[]string{fileA, fileAB, fileBA}, "/rmt", notRecursive},
 			&remotetest.MockRemoteActor{},
 			wants{
-				files: []string{"/rmt/fileA", "/rmt/fileAB", "/rmt/fileBA"},
-				dirs:  []string{"/rmt"},
-				err:   false}},
+				files:     []string{"/rmt/fileA", "/rmt/fileAB", "/rmt/fileBA"},
+				fileModes: []os.FileMode{0755, 0760, 0770},
+				dirs:      []string{"/rmt"},
+				dirModes:  []os.FileMode{0644}, // base dir always created with 0644
+				err:       false}},
 		{"copy files but not dir to remote when recursive is false",
 			args{[]string{fileA, dirA, fileBA}, "/home", notRecursive},
 			&remotetest.MockRemoteActor{},
 			wants{
-				files: []string{"/home/fileA", "/home/fileBA"},
-				dirs:  []string{"/home"},
-				err:   true}},
+				files:     []string{"/home/fileA", "/home/fileBA"},
+				fileModes: []os.FileMode{0755, 0770},
+				dirs:      []string{"/home"},
+				dirModes:  []os.FileMode{0644},
+				err:       true}},
 		{"cannot create remote root dir",
 			args{[]string{fileA, fileB}, "/nope", notRecursive},
 			&remotetest.MockRemoteActor{CreateDirErrorOn: "/nope"},
 			wants{
 				dirs:     []string{"/nope"},
+				dirModes: []os.FileMode{0644},
 				dirFails: []string{"/nope"},
 				err:      true}},
 		{"copy dirs and files when recursive is true",
@@ -82,35 +90,48 @@ func TestFileCopier(t *testing.T) {
 			&remotetest.MockRemoteActor{},
 			wants{
 				// since fileBA is specified directly, it should be copied into the remote root
-				files: []string{"/etc/fileBA", "/etc/dirA/fileAA", "/etc/dirA/fileAB"},
-				dirs:  []string{"/etc", "/etc/dirA"},
-				err:   false}},
+				files:     []string{"/etc/fileBA", "/etc/dirA/fileAA", "/etc/dirA/fileAB"},
+				fileModes: []os.FileMode{0770, 0700, 0760},
+				dirs:      []string{"/etc", "/etc/dirA"},
+				dirModes:  []os.FileMode{0644, 0744},
+				err:       false}},
 		{"fail to copy write-only dirs and files",
 			args{[]string{fileWO, dirWO, fileWOA}, "/root", recursive},
 			&remotetest.MockRemoteActor{},
 			wants{
-				dirs: []string{"/root"},
-				err:  true}},
+				dirs:     []string{"/root"},
+				dirModes: []os.FileMode{0644},
+				err:      true}},
 		{"cannot create remote dir",
 			args{[]string{dirA, fileB}, "/tmp", recursive},
 			&remotetest.MockRemoteActor{CreateDirErrorOn: "dirA"},
 			wants{
-				dirs:     []string{"/tmp", "/tmp/dirA"},
-				dirFails: []string{"/tmp/dirA"},
-				files:    []string{"/tmp/fileB"}, // do not attempt to copy files in tmp
-				err:      true}},
+				dirs:      []string{"/tmp", "/tmp/dirA"},
+				dirModes:  []os.FileMode{0644, 0744},
+				dirFails:  []string{"/tmp/dirA"},
+				files:     []string{"/tmp/fileB"}, // do not attempt to copy files in tmp
+				fileModes: []os.FileMode{0750},
+				err:       true}},
 		{"cannot create remote file",
 			args{[]string{dirA, fileB}, "/dev", recursive},
 			&remotetest.MockRemoteActor{CopyFileErrorOn: "fileAA"},
 			wants{
 				dirs:      []string{"/dev", "/dev/dirA"},
+				dirModes:  []os.FileMode{0644, 0744},
 				files:     []string{"/dev/fileB", "/dev/dirA/fileAA", "/dev/dirA/fileAB"},
+				fileModes: []os.FileMode{0750, 0700, 0760},
 				fileFails: []string{"/dev/dirA/fileAA"},
 				err:       true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := tt.actor
+			a.DirCreates = []string{}
+			a.DirCreateModes = []os.FileMode{}
+			a.DirCreateFails = []string{}
+			a.FileCopies = []string{}
+			a.FileCopyModes = []os.FileMode{}
+			a.FileCopyFails = []string{}
 			action := FileCopier(tt.args.localSourcePaths, tt.args.remoteDestDir, tt.args.opts)
 			_, e, err := action(a)
 			fmt.Println(e)
@@ -118,14 +139,12 @@ func TestFileCopier(t *testing.T) {
 			assert.True(t, (err != nil) == tt.wants.err) //err received when expected
 
 			assert.Zero(t, len(a.Commands))
-			dirs := remotetest.Clear(&a.DirCreates)
-			dirFails := remotetest.Clear(&a.DirCreateFails)
-			files := remotetest.Clear(&a.FileCopies)
-			fileFails := remotetest.Clear(&a.FileCopyFails)
-			testutil.CompareStringLists(t, tt.wants.dirs, dirs, "DirCreates")
-			testutil.CompareStringLists(t, tt.wants.dirFails, dirFails, "DirCreateFails")
-			testutil.CompareStringLists(t, tt.wants.files, files, "FileCopies")
-			testutil.CompareStringLists(t, tt.wants.fileFails, fileFails, "FileCopyFails")
+			assert.ElementsMatch(t, tt.wants.dirs, a.DirCreates, "DirCreates")
+			assert.ElementsMatch(t, tt.wants.dirModes, a.DirCreateModes, "DirCreateModes")
+			assert.ElementsMatch(t, tt.wants.dirFails, a.DirCreateFails, "DirCreateFails")
+			assert.ElementsMatch(t, tt.wants.files, a.FileCopies, "FileCopies")
+			assert.ElementsMatch(t, tt.wants.fileModes, a.FileCopyModes, "FileCopyModes")
+			assert.ElementsMatch(t, tt.wants.fileFails, a.FileCopyFails, "FileCopyFails")
 		})
 	}
 }

--- a/internal/util/testutil/testutil.go
+++ b/internal/util/testutil/testutil.go
@@ -1,11 +1,9 @@
 package testutil
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"testing"
 )
 
 // TempDir creates a new temp dir with prefix for testing. Returns dir name and cleanup function.
@@ -22,30 +20,7 @@ func WriteFile(path, contents string, perms os.FileMode) {
 	if err := ioutil.WriteFile(path, []byte(contents), perms); err != nil {
 		log.Fatalf("failed to create test file %s. %+v", path, err)
 	}
-}
-
-// CompareStringLists ensures that the expected and got string lists have exactly the same elements.
-func CompareStringLists(t *testing.T, expected []string, got []string, name string) {
-	g := make([]string, len(got))
-	copy(g, got)
-	var err error
-	for _, e := range expected {
-		g, err = removeFromList(e, g)
-		//fmt.Println(g)
-		if err != nil {
-			t.Errorf("%s: %+v", name, err)
-		}
+	if err := os.Chmod(path, perms); err != nil {
+		log.Fatalf("failed to set perms on test file %s. %+v", path, err)
 	}
-	if len(g) > 0 {
-		t.Errorf("%s has extraneous items: %+v", name, g)
-	}
-}
-
-func removeFromList(key string, list []string) ([]string, error) {
-	for i, s := range list {
-		if s == key {
-			return append(list[:i], list[i+1:]...), nil // remove element & return new list
-		}
-	}
-	return list, fmt.Errorf("%s not in list %+v", key, list)
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,6 +24,8 @@ run:
 
 teardown:
 	@ echo "Tearing down test hosts..."
+	@ docker kill $(RUNNER_NAME) || true
+	@ docker rm $(RUNNER_NAME) || true
 	@ for i in $$(seq 1 $(NUM_HOSTS)); do \
 		host=$(HOST_BASENAME)-$$i ; \
 		docker stop $$host ; \

--- a/test/tests/shared.sh
+++ b/test/tests/shared.sh
@@ -60,7 +60,7 @@ function assert_failure () {
 }
 
 function assert_output_count () { # 1) output desired 2) desired count
-  if [ "$(grep --count "$1" /tmp/output)" == "$2" ]; then
+  if [ "$(grep --count --regexp "$1" /tmp/output)" == "$2" ]; then
     pass "'$1' is in output exactly $2 times"
   else
     cat /tmp/output


### PR DESCRIPTION
Copy files from local to remote with permissions intact. The root
directory on the remote host to which files and dirs will be copied will
be created with permissions 0644 if it does not exist when the copy
begins.

Closes #15

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>