### PR TITLE
Use string slice for host-groups arg

### DIFF
--- a/cmd/octopus/config/cli.go
+++ b/cmd/octopus/config/cli.go
@@ -70,7 +70,7 @@ func init() {
 	// Persistent top-level flags
 	OctopusCmd.PersistentFlags().StringP("groups-file", "f", defaultGroupsFile,
 		"file which defines groups of remote hosts available for execution")
-	OctopusCmd.PersistentFlags().StringP("host-groups", "g", "",
+	OctopusCmd.PersistentFlags().StringSliceP("host-groups", "g", []string{},
 		"comma-separated list of host groups; the command will be run on each host in every group")
 	OctopusCmd.PersistentFlags().StringP("identity-file", "i", "$HOME/.ssh/id_rsa",
 		"(ssh) file from which the identity (private key) for public key authentication is read")

--- a/cmd/octopus/config/octopus.go
+++ b/cmd/octopus/config/octopus.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/spf13/viper"
 
@@ -29,8 +28,8 @@ func TrainOctopus() (*octopus.Octopus, error) {
 	logger.Info.Println("Config file used: ", viper.ConfigFileUsed())
 	logger.Info.Println("Parsing global flags")
 
-	rawHostGroups := viper.GetString("host-groups")
-	if rawHostGroups == "" {
+	hostGroups := viper.GetStringSlice("host-groups")
+	if len(hostGroups) == 0 {
 		// host-groups is not required for 'version' command; only commands that require an octopus
 		// to be created. Do a manual check here so that Cobra doesn't check 'version' for
 		// host-groups. Do not return an error here, but instead print to stderr and exit nonzero
@@ -39,7 +38,7 @@ func TrainOctopus() (*octopus.Octopus, error) {
 		os.Stderr.WriteString(OctopusCmd.UsageString())
 		os.Exit(-1)
 	}
-	hostGroups := strings.Split(rawHostGroups, ",")
+	logger.Info.Println("Host groups:", hostGroups)
 
 	groupsFile := getAbsFilePath(viper.GetString("groups-file"))
 	identityFile := getAbsFilePath(viper.GetString("identity-file"))


### PR DESCRIPTION
This allows multiple host groups to be specified by multiple
`--host-groups|-g` options.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>