### PR TITLE
Deploy built binaries via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ before_install:
 
 matrix:
   include:
+    # `make test.integration` target currently only works on linux.
     - os:  linux
-      env: GOOS=linux GOARCH=amd64 SUITES='test test.integration'
+      env: GOOS=linux GOARCH=amd64 SUITES='test test.smoke test.integration'
+    # Nov.2018: Travis CI does not support running Docker on OSX, and future support is not planned.
+    # The best testing we can do currently is to do unit tests.
     - os:  osx
       env: GOOS=darwin GOARCH=amd64 SUITES='test'
 
@@ -23,3 +26,12 @@ script: make ${SUITES}
 branches:
   only:
   - master
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  file:
+    - "_output/octopus-static-$VERSION-$GOOS-$GOARCH"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,9 @@ $(shell mkdir -p groupfile)
 all: teardown build setup run
 	@ $(MAKE) teardown
 
+smoke: teardown build setup quick
+	@ $(MAKE) teardown
+
 build:
 	@ docker build --tag $(IMAGE_TAG) .
 
@@ -21,6 +24,11 @@ setup:
 
 run:
 	@ ./run-tests.sh
+
+quick:
+	@ echo ""
+	@ if ./quicktest.sh; then echo "   QUICK TEST SUCCESSFUL"; else echo "   QUICK TEST FAILED"; fi
+	@ echo ""
 
 teardown:
 	@ echo "Tearing down test hosts..."

--- a/test/quicktest
+++ b/test/quicktest
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# quicktest checks that the current system can call basic Octopus functionality against test hosts.
+
+# Env vars should be exported by makefile
+echo ""
+echo "Running quicktest with config:"
+echo "  NUM_HOSTS: $NUM_HOSTS"
+echo "  HOST_BASENAME: $HOST_BASENAME"
+echo "  GROUPFILE: $GROUPFILE"
+echo ""
+
+set -x
+
+# Most basic test is to copy a dir to all hosts and then run 'ls' on the dir which should now have
+# been created on the hosts.
+_output/octopus -i "$PWD"/.ssh/id_rsa -f "$GROUPFILE" -g all copy -r "$PWD"/.ssh/ /root/quicktest/
+_output/octopus -i "$PWD"/.ssh/id_rsa -f "$GROUPFILE" -g all run 'ls -alFh /root/quicktest/.ssh/'

--- a/test/quicktest.sh
+++ b/test/quicktest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# quicktest checks that the current system can call basic Octopus functionality against test hosts.
+
+# Env vars should be exported by makefile
+echo ""
+echo "Running quicktest with config:"
+echo "  NUM_HOSTS: $NUM_HOSTS"
+echo "  HOST_BASENAME: $HOST_BASENAME"
+echo "  GROUPFILE: $GROUPFILE"
+echo ""
+
+set -x
+
+# Most basic test is to copy a dir to all hosts and then run 'ls' on the dir which should now have
+# been created on the hosts.
+_output/octopus -i "$PWD"/.ssh/id_rsa -f "$GROUPFILE" -g all copy -r "$PWD"/.ssh/ /root/quicktest/
+_output/octopus -i "$PWD"/.ssh/id_rsa -f "$GROUPFILE" -g all run 'ls -alFh /root/quicktest/.ssh/'


### PR DESCRIPTION
Add quick smoke test for testing that each arch's build works properly
without needing to run integration tests which only work on linux/amd64
currently. Unfortunately, Travis CI's OSX environment does not support Docker, and it doesn't seem that any plans are in place to add this in the future:
- https://github.com/travis-ci/travis-ci/issues/9044
- https://github.com/travis-ci/travis-ci/issues/5738

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>