### PR TITLE
Start adding bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test.smoke: vendor build
 install: vendor
 	go install $(ALL_BUILDFLAGS) $(GO_BUILD_TARGET)
 
+completion:
+	@ # Currently only generates a basic completion shell file and prints to stdout
+	@ go run cmd/octopus/bashcompletion/generate.go
+
 clean:
 	rm -rf $(OUTPUT_DIR)
 	rm -rf vendor/

--- a/cmd/octopus/bashcompletion/generate.go
+++ b/cmd/octopus/bashcompletion/generate.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+
+	"github.com/BlaineEXE/octopus/cmd/octopus/config"
+	_ "github.com/BlaineEXE/octopus/cmd/octopus/root"
+)
+
+func main() {
+	config.OctopusCmd.GenBashCompletion(os.Stdout)
+}

--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -9,19 +9,8 @@ import (
 	"log"
 
 	"github.com/BlaineEXE/octopus/cmd/octopus/config"
-	"github.com/BlaineEXE/octopus/cmd/octopus/copy"
-	"github.com/BlaineEXE/octopus/cmd/octopus/run"
-	"github.com/BlaineEXE/octopus/cmd/octopus/version"
+	_ "github.com/BlaineEXE/octopus/cmd/octopus/root"
 )
-
-func init() {
-	octopusCmd := config.OctopusCmd
-
-	// Subcommands
-	octopusCmd.AddCommand(version.VersionCmd)
-	octopusCmd.AddCommand(run.RunCmd)
-	octopusCmd.AddCommand(copy.CopyCmd)
-}
 
 func main() {
 	if err := config.OctopusCmd.Execute(); err != nil {

--- a/cmd/octopus/root/init.go
+++ b/cmd/octopus/root/init.go
@@ -1,0 +1,17 @@
+package root
+
+import (
+	"github.com/BlaineEXE/octopus/cmd/octopus/config"
+	"github.com/BlaineEXE/octopus/cmd/octopus/copy"
+	"github.com/BlaineEXE/octopus/cmd/octopus/run"
+	"github.com/BlaineEXE/octopus/cmd/octopus/version"
+)
+
+func init() {
+	octopusCmd := config.OctopusCmd
+
+	// Subcommands
+	octopusCmd.AddCommand(version.VersionCmd)
+	octopusCmd.AddCommand(run.RunCmd)
+	octopusCmd.AddCommand(copy.CopyCmd)
+}


### PR DESCRIPTION
Add ability to generate most basic bash completion. `make completion`
prints a completion shell script to stdout.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>