### PR TITLE
Add `host-groups` command

### DIFF
--- a/cmd/octopus/hostgroups/hostgroups.go
+++ b/cmd/octopus/hostgroups/hostgroups.go
@@ -1,0 +1,50 @@
+// Package hostgroups defines the 'octopus host-groups' command behavior. It's one responsibility
+// is to report the list of host groups octopus is able to parse from the host groups file.
+package hostgroups
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/BlaineEXE/octopus/internal/octopus"
+	"github.com/BlaineEXE/octopus/internal/util"
+)
+
+const (
+	aboutText = "Parse the host groups file, and report the available groups"
+)
+
+// HostGroupsCommand is the 'host-groups' command definition which prints the valid host groups.
+var HostGroupsCommand = &cobra.Command{
+	Use:   "host-groups",
+	Short: aboutText,
+	Long:  fmt.Sprintf("\n%s", aboutText),
+	Args:  cobra.ExactArgs(0), // support no args
+	RunE: func(cmd *cobra.Command, args []string) error {
+		o := octopus.New(
+			nil,
+			[]string{},
+			getAbsFilePath(viper.GetString("groups-file")),
+		)
+
+		gs, err := o.ValidHostGroups()
+		if err != nil {
+			return err
+		}
+		for _, g := range gs {
+			fmt.Printf("%s\n", g)
+		}
+		return nil
+	},
+}
+
+func getAbsFilePath(path string) string {
+	a, err := util.AbsPath(path)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	return a
+}

--- a/cmd/octopus/root/init.go
+++ b/cmd/octopus/root/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/BlaineEXE/octopus/cmd/octopus/config"
 	"github.com/BlaineEXE/octopus/cmd/octopus/copy"
 	"github.com/BlaineEXE/octopus/cmd/octopus/run"
+	"github.com/BlaineEXE/octopus/cmd/octopus/hostgroups"
 	"github.com/BlaineEXE/octopus/cmd/octopus/version"
 )
 
@@ -12,6 +13,7 @@ func init() {
 
 	// Subcommands
 	octopusCmd.AddCommand(version.VersionCmd)
+	octopusCmd.AddCommand(hostgroups.HostGroupsCommand)
 	octopusCmd.AddCommand(run.RunCmd)
 	octopusCmd.AddCommand(copy.CopyCmd)
 }

--- a/internal/octopus/octopus.go
+++ b/internal/octopus/octopus.go
@@ -4,6 +4,7 @@ package octopus
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/BlaineEXE/octopus/internal/logger"
@@ -26,6 +27,26 @@ func New(c remote.Connector, hostGroups []string, groupsFile string) *Octopus {
 		hostGroups:      hostGroups,
 		groupsFile:      groupsFile,
 	}
+}
+
+// ValidHostGroups returns a list of host groups which are available for Octopus to run against.
+func (o *Octopus) ValidHostGroups() ([]string, error) {
+	logger.Info.Println("groups file: ", o.groupsFile)
+
+	f, err := os.Open(o.groupsFile)
+	if err != nil {
+		return []string{}, fmt.Errorf("could not load groups file: %+v", err)
+	}
+
+	g, err := getAllGroupsInFile(f)
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to parse groups file. %+v", err)
+	}
+	gs := []string{}
+	for k := range g {
+		gs = append(gs, k)
+	}
+	return gs, nil
 }
 
 // Do sends out tentacles to all hosts in the host group(s) in individual goroutines and collects

--- a/test/tests/01_config.sh
+++ b/test/tests/01_config.sh
@@ -68,3 +68,34 @@ EOF
   assert_success "with config file in $placement" octopus -g all run hostname
   rm -rf "$placement/$configfile_name"
 done
+
+popd 1> /dev/null
+
+echo ""
+echo "Running 'octopus host-groups' tests ..."
+
+assert_success "with default groups" octopus host-groups
+assert_output_count "one" 1
+assert_output_count "rest" 1
+
+# create custom, more complex group file for this test
+mkdir -p "$HOME/work"
+mv "$GROUPFILE" "$HOME/work/groups-file"
+assert_failure "with groups file not found" octopus host-groups
+cat > "$GROUPFILE" << EOF
+one="1.1.1.1"
+two="2.2.2.2"
+three="3.3.3.3"
+
+first="$one"
+rest="$two"
+rest="$rest $three"
+EOF
+assert_success "with custom groups file" octopus host-groups
+assert_output_count "one" 1
+assert_output_count "two" 1
+assert_output_count "three" 1
+assert_output_count "first" 1
+assert_output_count "rest" 1
+assert_num_output_lines_with_text 5
+mv "$HOME/work/groups-file" "$GROUPFILE"

--- a/test/tests/shared.sh
+++ b/test/tests/shared.sh
@@ -61,10 +61,20 @@ function assert_failure () {
 
 function assert_output_count () { # 1) output desired 2) desired count
   if [ "$(grep --count --regexp "$1" /tmp/output)" == "$2" ]; then
-    pass "'$1' is in output exactly $2 times"
+    pass "'$1'" is in output exactly "$2" times
   else
     cat /tmp/output
-    fail "'$1' is in output $(grep --count "$1" /tmp/output) times; expected $2"
+    fail "'$1'" is in output "$(grep --count "$1" /tmp/output)" "times;" expected "$2"
+  fi
+}
+
+function assert_num_output_lines_with_text () { # 1) number of output lines with text desired
+  lines="$(grep --extended-regexp '.+' /tmp/output | wc --lines)"
+  if [ "$lines" == "$1" ]; then
+    pass output has exactly "$1" text lines
+  else
+    cat /tmp/output
+    fail output has "$lines" text lines; expected "$1"
   fi
 }
 


### PR DESCRIPTION
`host-groups` command will show the host groups which Octopus can parse
from the groups file.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>