### PR TITLE
Do not use custom-written group variable parser

### DIFF
--- a/internal/octopus/groupsfile_test.go
+++ b/internal/octopus/groupsfile_test.go
@@ -18,40 +18,40 @@ func init() {
 
 const parsableGroups = `
 # simple
-a="1.1.1.1"
-b='2.2.2.2'
-_3="3.3.3.3"
-_4='4.4.4.4'
+export a="1.1.1.1"
+export b='2.2.2.2'
+export _3="3.3.3.3"
+export _4='4.4.4.4'
 
 # double-quoted multi, all variants
-d34="3.3.3.3 4.4.4.4"
-d5_6="5.5.5.5
+export d34="3.3.3.3 4.4.4.4"
+export d5_6="5.5.5.5
 6.6.6.6"
-d_78="
+export d_78="
 7.7.7.7 8.8.8.8"
-d_9_10="
+export d_9_10="
 9.9.9.9
 10.10.10.10"
-d_11_12_="
+export d_11_12_="
 11.11.11.11
 12.12.12.12
 "
 
 # single-quoted multi
-s56='5.5.5.5 6.6.6.6'
-s_7_8_='
+export s56='5.5.5.5 6.6.6.6'
+export s_7_8_='
 7.7.7.7
 8.8.8.8
 '
 
 # leading/trailing space
-ltd78=" 7.7.7.7 8.8.8.8 "
-lts910=' 9.9.9.9 10.10.10.10 '
+export ltd78=" 7.7.7.7 8.8.8.8 "
+export lts910=' 9.9.9.9 10.10.10.10 '
 
 # mixed
-md9to12="9.9.9.9 10.10.10.10
+export md9to12="9.9.9.9 10.10.10.10
 11.11.11.11 12.12.12.12"
-ms13to16='13.13.13.13 14.14.14.14
+export ms13to16='13.13.13.13 14.14.14.14
 15.15.15.15 16.16.16.16'
 `
 
@@ -60,8 +60,12 @@ const noGroups = `
 `
 
 const unparsableGroups = `
-a='9.9.9.9'
-t="1.1.1.1'
+export a='9.9.9.9'
+export t="1.1.1.1'
+`
+
+const invalidVarName = `
+export a&b='1.1.1.1'
 `
 
 func Test_getAddrsFromGroupsFile(t *testing.T) {
@@ -103,6 +107,7 @@ func Test_getAddrsFromGroupsFile(t *testing.T) {
 		{"arbitrary, out of order selection", goodGroupsFile, []string{"md9to12", "ltd78", "_4"},
 			[]string{"9.9.9.9", "10.10.10.10", "11.11.11.11", "12.12.12.12",
 				"7.7.7.7", "8.8.8.8", "4.4.4.4"}, false},
+		{"invalid var name", invalidVarName, []string{}, []string{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/octopus/octopus.go
+++ b/internal/octopus/octopus.go
@@ -4,7 +4,7 @@ package octopus
 
 import (
 	"fmt"
-	"os"
+	"sort"
 	"strings"
 
 	"github.com/BlaineEXE/octopus/internal/logger"
@@ -33,19 +33,15 @@ func New(c remote.Connector, hostGroups []string, groupsFile string) *Octopus {
 func (o *Octopus) ValidHostGroups() ([]string, error) {
 	logger.Info.Println("groups file: ", o.groupsFile)
 
-	f, err := os.Open(o.groupsFile)
-	if err != nil {
-		return []string{}, fmt.Errorf("could not load groups file: %+v", err)
-	}
-
-	g, err := getAllGroupsInFile(f)
+	g, err := getAllGroupsInFile(o.groupsFile)
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to parse groups file. %+v", err)
 	}
-	gs := []string{}
+	gs := make([]string, 0, len(g))
 	for k := range g {
 		gs = append(gs, k)
 	}
+	sort.Strings(gs)
 	return gs, nil
 }
 

--- a/test/setup-test-hosts.sh
+++ b/test/setup-test-hosts.sh
@@ -21,11 +21,11 @@ done
 cat << EOF > "$GROUPFILE"
 #!/usr/bin/env bash
 
-one='$one'
-rest='$rest'
+export one='$one'
+export rest='$rest'
 
 EOF
-echo 'all="$one $rest"' >> "$GROUPFILE"
+echo 'export all="$one $rest"' >> "$GROUPFILE"
 echo '' >> "$GROUPFILE"
 
 echo "  "$GROUPFILE" file:"

--- a/test/tests/01_config.sh
+++ b/test/tests/01_config.sh
@@ -82,20 +82,19 @@ assert_output_count "rest" 1
 mkdir -p "$HOME/work"
 mv "$GROUPFILE" "$HOME/work/groups-file"
 assert_failure "with groups file not found" octopus host-groups
-cat > "$GROUPFILE" << EOF
-one="1.1.1.1"
-two="2.2.2.2"
+cat > "$GROUPFILE" << 'EOF'
+export one="1.1.1.1"
+export two="2.2.2.2"
 three="3.3.3.3"
 
-first="$one"
+export first="$one"
 rest="$two"
-rest="$rest $three"
+export rest="$rest $three"
 EOF
 assert_success "with custom groups file" octopus host-groups
 assert_output_count "one" 1
 assert_output_count "two" 1
-assert_output_count "three" 1
 assert_output_count "first" 1
 assert_output_count "rest" 1
-assert_num_output_lines_with_text 5
+assert_num_output_lines_with_text 4
 mv "$HOME/work/groups-file" "$GROUPFILE"


### PR DESCRIPTION
Instead of writing a custom parser in Go, rely on Bash to parse
variables automatically. Use `env` and `bash` commands to achieve the
functionality. The downside of this is that variables in the host groups
file must now be `export`-ed to be used by Octopus.

In some ways, this is a feature because `export`-ed variables were not
previously supported. And forcing variables to use `export` isn't a bad
requirement, as there is a shellcheck linter warning if unused variables
aren't exported, and the host groups file will have mostly unused
variables.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>