### PR TITLE
fix #47: allow host groups to have zero members

### DIFF
--- a/internal/octopus/groupsfile.go
+++ b/internal/octopus/groupsfile.go
@@ -32,13 +32,11 @@ var getAddrsFromGroupsFile = func(hostGroups []string, groupsFile string) ([]str
 	cmd := exec.Command("bash", "-ec",
 		fmt.Sprintf("source %s ; echo %s", groupsFile, strings.Join(gVars, " ")))
 	o, err := cmd.CombinedOutput()
-	// convert to string which has exactly one newline
-	os := strings.TrimRight(string(o), "\n")
 	if err != nil {
-		return []string{}, fmt.Errorf("could not get groups %+v from %s: %+v\n%s", hostGroups, groupsFile, err, os)
+		return []string{}, fmt.Errorf("could not get groups %+v from %s: %+v\n%s", hostGroups, groupsFile, err, string(o))
 	}
 
-	addrs := strings.Split(os, " ")
+	addrs := strings.Fields(string(o))
 	return addrs, nil
 }
 

--- a/test/setup-test-hosts.sh
+++ b/test/setup-test-hosts.sh
@@ -23,6 +23,7 @@ cat << EOF > "$GROUPFILE"
 
 export one='$one'
 export rest='$rest'
+export empty=''
 
 EOF
 echo 'export all="$one $rest"' >> "$GROUPFILE"

--- a/test/tests/01_config.sh
+++ b/test/tests/01_config.sh
@@ -77,6 +77,7 @@ echo "Running 'octopus host-groups' tests ..."
 assert_success "with default groups" octopus host-groups
 assert_output_count "one" 1
 assert_output_count "rest" 1
+assert_output_count "empty" 1
 
 # create custom, more complex group file for this test
 mkdir -p "$HOME/work"

--- a/test/tests/02_run.sh
+++ b/test/tests/02_run.sh
@@ -46,3 +46,7 @@ for host in $HOSTNAMES; do # command failure should still report hostnames
   assert_output_count "$host" 1
 done
 octopus -g one run "mv ${ls_location}.bkp ${ls_location}" 1> /dev/null
+
+
+assert_success 'with group having no members' octopus -g empty run 'hostname'
+assert_num_output_lines_with_text 0


### PR DESCRIPTION
Allow host groups to have zero members. Octopus will merely do nothing
for those groups and stll return successfully.

Resolves #47 

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>